### PR TITLE
handle reserved ranges

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,7 @@
-gem 'iptoasn', :path => "."  
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'iptoasn', path: '.'
+
+gem 'rubocop', '~> 1.69'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gem 'iptoasn', :path => "."  

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,16 @@
+PATH
+  remote: .
+  specs:
+    iptoasn (0.5.0)
+
+GEM
+  specs:
+
+PLATFORMS
+  arm64-darwin-23
+
+DEPENDENCIES
+  iptoasn!
+
+BUNDLED WITH
+   2.2.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    iptoasn (0.5.0)
+    iptoasn (0.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,13 +4,41 @@ PATH
     iptoasn (0.5.0)
 
 GEM
+  remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
+    json (2.9.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.26.3)
+    parser (3.3.6.0)
+      ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
+    rainbow (3.1.1)
+    regexp_parser (2.10.0)
+    rubocop (1.69.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.36.2, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.37.0)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (3.1.3)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   arm64-darwin-23
 
 DEPENDENCIES
   iptoasn!
+  rubocop (~> 1.69)
 
 BUNDLED WITH
    2.2.3

--- a/build_indexes.rb
+++ b/build_indexes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ipaddr'
 
 def ip_to_int(ip)
@@ -6,7 +8,7 @@ end
 
 def parse_tsv_file(file_name)
   result = []
-  File.foreach(file_name).with_index do |line, index|
+  File.foreach(file_name).with_index do |line, _index|
     fields = line.strip.split("\t")
     range_start = ip_to_int(fields[0])
     range_end = ip_to_int(fields[1])
@@ -21,7 +23,7 @@ def parse_tsv_file(file_name)
 end
 
 index = []
-Dir.glob(File.join("tmp/", "chunk_*")) do |file|
+Dir.glob(File.join('tmp/', 'chunk_*')) do |file|
   puts "Processing file: #{file}"
   tsv_file = parse_tsv_file(file)
   filename = File.basename(file)
@@ -32,8 +34,8 @@ Dir.glob(File.join("tmp/", "chunk_*")) do |file|
   chunk_source = "def chunk_#{filename}()\n\t#{tsv_file.inspect}\nend\n"
   File.write("chunks/#{filename}.rb", chunk_source)
 
-  index << [ip_address_min, ip_address_max, "#{filename}"]
+  index << [ip_address_min, ip_address_max, filename.to_s]
 end
 
 index_source = "def chunk_index()\n\t#{index.inspect}\nend\n"
-File.write("index.rb", index_source)
+File.write('index.rb', index_source)

--- a/example.rb
+++ b/example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'iptoasn'
 
 finder = IpToAsn.new

--- a/iptoasn.gemspec
+++ b/iptoasn.gemspec
@@ -4,15 +4,15 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
-  s.name = "iptoasn"
-  s.version = "0.5.0"
-  s.authors = ["OMAR"]
-  s.summary = "The IP to ASN dataset wrapped in a Ruby gem"
+  s.name = 'iptoasn'
+  s.version = '0.5.0'
+  s.authors = ['OMAR']
+  s.summary = 'The IP to ASN dataset wrapped in a Ruby gem'
   s.description = "This gem wraps the IP to ASN dataset. It uses lazy loading so it doesn't load the entire ~25M dataset all at once."
-  s.license = "MIT"
-  s.homepage = "https://github.com/ancat/iptoasn"
+  s.license = 'MIT'
+  s.homepage = 'https://github.com/ancat/iptoasn'
 
-  s.files = Dir["README.md", "lib/**/*.rb"]
+  s.files = Dir['README.md', 'lib/**/*.rb']
 
-  s.required_ruby_version = ">= 3.0"
+  s.required_ruby_version = '>= 3.0'
 end

--- a/iptoasn.gemspec
+++ b/iptoasn.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = 'iptoasn'
-  s.version = '0.5.0'
+  s.version = '0.6.0'
   s.authors = ['OMAR']
   s.summary = 'The IP to ASN dataset wrapped in a Ruby gem'
   s.description = "This gem wraps the IP to ASN dataset. It uses lazy loading so it doesn't load the entire ~25M dataset all at once."

--- a/lib/iptoasn.rb
+++ b/lib/iptoasn.rb
@@ -1,1 +1,3 @@
-require_relative 'main.rb'
+# frozen_string_literal: true
+
+require_relative 'main'

--- a/lib/main.rb
+++ b/lib/main.rb
@@ -1,22 +1,24 @@
+# frozen_string_literal: true
+
 require 'ipaddr'
-require_relative 'index.rb'
+require_relative 'index'
 
 class IpToAsn
   def initialize
     @index = chunk_index
     @cache = {}
-    @chunk_dir = "./chunks"
+    @chunk_dir = './chunks'
     @reserved_ranges = {
       IPAddr.new('10.0.0.0/8') => 'RFC1918 Private',
       IPAddr.new('172.16.0.0/12') => 'RFC1918 Private',
       IPAddr.new('192.168.0.0/16') => 'RFC1918 Private',
       IPAddr.new('0.0.0.0/8') => 'Current Network',
       IPAddr.new('127.0.0.0/8') => 'Loopback',
-      IPAddr.new('169.254.0.0/16') => 'Link Local',
+      IPAddr.new('169.254.0.0/16') => 'Link Local'
     }
   end
 
-  def lookup(ip_str)
+  def lookup(ip_str) # rubocop:disable Metrics/AbcSize
     reserved_range_name = find_range(
       ranges: @reserved_ranges,
       ip_address: ip_str
@@ -39,10 +41,11 @@ class IpToAsn
   end
 
   private
+
   def find_range(ranges:, ip_address:)
-    ranges.filter_map { |k, v|
+    ranges.filter_map do |k, v|
       v if k.include? ip_address
-    }.first
+    end.first
   end
 
   def binary_search(ranges, ip_str)

--- a/lib/main.rb
+++ b/lib/main.rb
@@ -6,9 +6,24 @@ class IpToAsn
     @index = chunk_index
     @cache = {}
     @chunk_dir = "./chunks"
+    @reserved_ranges = {
+      IPAddr.new('10.0.0.0/8') => 'RFC1918 Private',
+      IPAddr.new('172.16.0.0/12') => 'RFC1918 Private',
+      IPAddr.new('192.168.0.0/16') => 'RFC1918 Private',
+      IPAddr.new('0.0.0.0/8') => 'Current Network',
+      IPAddr.new('127.0.0.0/8') => 'Loopback',
+      IPAddr.new('169.254.0.0/16') => 'Link Local',
+    }
   end
 
   def lookup(ip_str)
+    reserved_range_name = find_range(
+      ranges: @reserved_ranges,
+      ip_address: ip_str
+    )
+
+    return { as_number: 0, country_code: 'XX', as_name: reserved_range_name } unless reserved_range_name.nil?
+
     chunk_name = binary_search(@index, ip_str).first
     return nil if chunk_name.nil?
 
@@ -18,9 +33,16 @@ class IpToAsn
     end
 
     result = binary_search(@cache[chunk_name], ip_str)
-    nil if result.empty?
+    return nil if result.empty?
 
     { as_number: result[0], country_code: result[1], as_name: result[2] }
+  end
+
+  private
+  def find_range(ranges:, ip_address:)
+    ranges.filter_map { |k, v|
+      v if k.include? ip_address
+    }.first
   end
 
   def binary_search(ranges, ip_str)


### PR DESCRIPTION
Attempts to address #1 by hardcoding some ranges. I copied some of the ranges [from wikipedia](https://en.wikipedia.org/wiki/Reserved_IP_addresses). Every lookup will consult the hardcoded list first before attempting to search the chunks. If there's a match, it'll return the hardcoded value with a Country Code of XX and AS number of 0. If there's not a match, it'll continue to search as normal.